### PR TITLE
Mast 1741 imfs create by mc are2.25 x bigger than inventory version with higher bitrate

### DIFF
--- a/src/bin/jp2/opj_compress.c
+++ b/src/bin/jp2/opj_compress.c
@@ -1269,6 +1269,7 @@ static int parse_cmdline_encoder(int argc, char **argv,
                 };
                 parameters->max_cs_size = limitMBitsSec[sublevel] * (1000 * 1000 / 8) /
                                           framerate;
+                parameters->max_comp_size = parameters->max_cs_size;
                 fprintf(stdout, "Setting max codestream size to %d bytes.\n",
                         parameters->max_cs_size);
             }

--- a/src/bin/jp2/opj_compress.c
+++ b/src/bin/jp2/opj_compress.c
@@ -2139,7 +2139,7 @@ int main(int argc, char **argv)
                 double msamplespersec;
                 if (image->numcomps == 3 &&
                         image->comps[1].dx == 2 &&
-                        image->comps[1].dy == 2) {
+                        image->comps[2].dx == 2) {
                     avgcomponents = 2;
                 }
                 msamplespersec = (double)image->x1 * image->y1 * avgcomponents * framerate /


### PR DESCRIPTION
* Bug Fix - Correct the max_comp_size coding parameter when setting the Sublevel codestream restriction
* Bug Fix - Correct the calculation of Msamples/sec when checking the Mainlevel codestream restriction